### PR TITLE
Improved usability of errors

### DIFF
--- a/Pyrobase.xcodeproj/project.pbxproj
+++ b/Pyrobase.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		B9BC18521EF22D860003FDDB /* PyroTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9BC18511EF22D860003FDDB /* PyroTransaction.swift */; };
 		B9BC18561EF254A90003FDDB /* PyroTransactionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9BC18551EF254A90003FDDB /* PyroTransactionTest.swift */; };
 		B9C58E4A1EF3B0F90005EBE7 /* PyroTransactionParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C58E491EF3B0F90005EBE7 /* PyroTransactionParameter.swift */; };
+		B9DAF3771F28738D00E478F0 /* RequestErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DAF3761F28738D00E478F0 /* RequestErrorTest.swift */; };
 		B9EEEB431EE91CE900825311 /* RequestOperationMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9EEEB421EE91CE900825311 /* RequestOperationMock.swift */; };
 		B9FC64AF1EE7A40800DE7CF3 /* RequestMethodTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC64AE1EE7A40800DE7CF3 /* RequestMethodTest.swift */; };
 		B9FC64B11EE7A4DB00DE7CF3 /* JSONRequestOperationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC64B01EE7A4DB00DE7CF3 /* JSONRequestOperationTest.swift */; };
@@ -125,6 +126,7 @@
 		B9BC18511EF22D860003FDDB /* PyroTransaction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PyroTransaction.swift; sourceTree = "<group>"; };
 		B9BC18551EF254A90003FDDB /* PyroTransactionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PyroTransactionTest.swift; sourceTree = "<group>"; };
 		B9C58E491EF3B0F90005EBE7 /* PyroTransactionParameter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PyroTransactionParameter.swift; sourceTree = "<group>"; };
+		B9DAF3761F28738D00E478F0 /* RequestErrorTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestErrorTest.swift; sourceTree = "<group>"; };
 		B9EEEB421EE91CE900825311 /* RequestOperationMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestOperationMock.swift; sourceTree = "<group>"; };
 		B9FC64AE1EE7A40800DE7CF3 /* RequestMethodTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestMethodTest.swift; sourceTree = "<group>"; };
 		B9FC64B01EE7A4DB00DE7CF3 /* JSONRequestOperationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONRequestOperationTest.swift; sourceTree = "<group>"; };
@@ -238,16 +240,17 @@
 				B999C9501EEA836600385AEA /* PyroAuthTest.swift */,
 				B989FD561EEFC4EC00AF9F58 /* PyroAuthTokenContentTest.swift */,
 				B90D2CF41EB70EE000FC0ADD /* PyrobaseTest.swift */,
+				B94021E01EFCEF28005B09D0 /* PyroEventSourceMessageTest.swift */,
 				B94021DE1EFCEAF5005B09D0 /* PyroEventSourceParserTest.swift */,
 				B94021DA1EFCE64A005B09D0 /* PyroEventSourceSessionProviderTest.swift */,
 				B9B8F2BF1EFA179700E610EF /* PyroEventSourceTest.swift */,
 				B956AC9C1EF8D2F9002D6B10 /* PyroTransactionTemporaryPathTest.swift */,
 				B9BC18551EF254A90003FDDB /* PyroTransactionTest.swift */,
+				B9DAF3761F28738D00E478F0 /* RequestErrorTest.swift */,
 				B9FC64AE1EE7A40800DE7CF3 /* RequestMethodTest.swift */,
 				B99651E21EB84EAB0046810D /* RequestPathTest.swift */,
-				B99651EB1EB858900046810D /* RequestTest.swift */,
-				B94021E01EFCEF28005B09D0 /* PyroEventSourceMessageTest.swift */,
 				B94021E21EFCF0C4005B09D0 /* RequestResponseTest.swift */,
+				B99651EB1EB858900046810D /* RequestTest.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -397,6 +400,7 @@
 				B9FC64B31EE7CCDA00DE7CF3 /* JSONSerializationMock.swift in Sources */,
 				B94021DB1EFCE64A005B09D0 /* PyroEventSourceSessionProviderTest.swift in Sources */,
 				B9FC64AF1EE7A40800DE7CF3 /* RequestMethodTest.swift in Sources */,
+				B9DAF3771F28738D00E478F0 /* RequestErrorTest.swift in Sources */,
 				B9EEEB431EE91CE900825311 /* RequestOperationMock.swift in Sources */,
 				B956AC9B1EF8BE4C002D6B10 /* PyroTransactionMock.swift in Sources */,
 				B9FC64B11EE7A4DB00DE7CF3 /* JSONRequestOperationTest.swift in Sources */,

--- a/Pyrobase/PyroEventSource.swift
+++ b/Pyrobase/PyroEventSource.swift
@@ -108,7 +108,7 @@ extension PyroEventSource: URLSessionDataDelegate {
             return
         }
         
-        if let responseError = response.isErroneous(task.response as? HTTPURLResponse) {
+        if let responseError = response.isErroneous(task.response as? HTTPURLResponse, data: data) {
             close()
             callback?.pyroEventSource(self, didReceiveError: responseError)
             
@@ -120,7 +120,7 @@ extension PyroEventSource: URLSessionDataDelegate {
     }
     
     public func urlSession(_ session: URLSession, dataTask task: URLSessionDataTask, didReceive httpResponse: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
-        if let responseError = response.isErroneous(httpResponse as? HTTPURLResponse) {
+        if let responseError = response.isErroneous(httpResponse as? HTTPURLResponse, data: nil) {
             close()
             callback?.pyroEventSource(self, didReceiveError: responseError)
             
@@ -138,7 +138,7 @@ extension PyroEventSource: URLSessionDataDelegate {
             return
         }
         
-        if let responseError = response.isErroneous(task.response as? HTTPURLResponse) {
+        if let responseError = response.isErroneous(task.response as? HTTPURLResponse, data: nil) {
             callback?.pyroEventSource(self, didReceiveError: responseError)
         }
     }

--- a/Pyrobase/Request.swift
+++ b/Pyrobase/Request.swift
@@ -55,7 +55,7 @@ public class Request: RequestProtocol {
                 return
             }
             
-            let error = self.response.isErroneous(response as? HTTPURLResponse)
+            let error = self.response.isErroneous(response as? HTTPURLResponse, data: data)
             
             guard error == nil else {
                 completion(.failed(error!))

--- a/Pyrobase/RequestResponse.swift
+++ b/Pyrobase/RequestResponse.swift
@@ -8,24 +8,39 @@
 
 public protocol RequestResponseProtocol {
     
-    func isErroneous(_ response: HTTPURLResponse?) -> Error?
+    func isErroneous(_ response: HTTPURLResponse?, data: Data?) -> Error?
 }
 
 public class RequestResponse: RequestResponseProtocol {
 
-    public func isErroneous(_ response: HTTPURLResponse?) -> Error? {
+    private(set) public var serializer: JSONSerialization.Type
+    
+    public init(serializer: JSONSerialization.Type = JSONSerialization.self) {
+        self.serializer = serializer
+    }
+    
+    public func isErroneous(_ response: HTTPURLResponse?, data: Data?) -> Error? {
         guard response != nil else {
             return nil
         }
         
         switch response!.statusCode {
-        case 400: return RequestError.badRequest
-        case 401: return RequestError.unauthorized
-        case 403: return RequestError.forbidden
-        case 404: return RequestError.notFound
-        case 500: return RequestError.internalServiceError
-        case 503: return RequestError.serviceUnavailable
+        case 400: return RequestError.badRequest(errorMessage(data))
+        case 401: return RequestError.unauthorized(errorMessage(data))
+        case 403: return RequestError.forbidden(errorMessage(data))
+        case 404: return RequestError.notFound(errorMessage(data))
+        case 500: return RequestError.internalServiceError(errorMessage(data))
+        case 503: return RequestError.serviceUnavailable(errorMessage(data))
         default: return nil
         }
+    }
+    
+    func errorMessage(_ data: Data?) -> String {
+        guard data != nil else {
+            return ""
+        }
+        
+        let info = (try? serializer.jsonObject(with: data!, options: [])) as? [AnyHashable: Any]
+        return (info?["error"] as? String) ?? ""
     }
 }

--- a/Pyrobase/RequestResult.swift
+++ b/Pyrobase/RequestResult.swift
@@ -20,10 +20,51 @@ public enum RequestError: Error {
     case nullJSON
     case unknown
     
-    case badRequest
-    case unauthorized
-    case forbidden
-    case notFound
-    case internalServiceError
-    case serviceUnavailable
+    case badRequest(String)
+    case unauthorized(String)
+    case forbidden(String)
+    case notFound(String)
+    case internalServiceError(String)
+    case serviceUnavailable(String)
+
+    public var code: Int {
+        switch self {
+        case .invalidURL: return -9000
+        case .unparseableJSON: return -9001
+        case .noURLResponse: return -9002
+        case .nullJSON: return -9003
+        case .unknown: return -9004
+        case .badRequest: return -9005
+        case .unauthorized: return -9006
+        case .forbidden: return -9007
+        case .notFound: return -9008
+        case .internalServiceError: return -9009
+        case .serviceUnavailable: return -9010
+        }
+    }
+    
+    public var message: String {
+        switch self {
+        case .invalidURL: return "URL is invalid"
+        case .unparseableJSON: return "Can not parse JSON"
+        case .noURLResponse: return "No URL response"
+        case .nullJSON: return "JSON is null"
+        case .unknown: return "Unknown error encountered"
+            
+        case .badRequest(let message),
+             .unauthorized(let message),
+             .forbidden(let message),
+             .notFound(let message),
+             .internalServiceError(let message),
+             .serviceUnavailable(let message):
+            return message
+        }
+    }
+}
+
+extension RequestError: Equatable {
+    
+    public static func ==(lhs: RequestError, rhs: RequestError) -> Bool {
+        return lhs.code == rhs.code && lhs.message == rhs.message
+    }
 }

--- a/PyrobaseTests/PyroEventSourceTest.swift
+++ b/PyrobaseTests/PyroEventSourceTest.swift
@@ -161,7 +161,7 @@ class PyroEventSourceTest: XCTestCase {
         let httpResponse = HTTPURLResponse(url: URL(string: "https://sampleio.com")!, statusCode: 500, httpVersion: nil, headerFields: nil)
         let task = URLSessionDataTaskMock(httpResponse: httpResponse)
         let data = Data(bytes: [0,1,1,2,3,5,8])
-        expectedRequestError = RequestError.internalServiceError
+        expectedRequestError = RequestError.internalServiceError("")
         eventSource = PyroEventSource.create(baseURL: baseURL, accessToken: accessToken)
         eventSource.state = .open
         eventSource.callback = self
@@ -194,7 +194,7 @@ class PyroEventSourceTest: XCTestCase {
         let httpResponse = HTTPURLResponse(url: URL(string: "https://sampleio.com")!, statusCode: 500, httpVersion: nil, headerFields: nil)
         let task = URLSessionDataTaskMock(httpResponse: httpResponse)
         let completion: (URLSession.ResponseDisposition) -> Void = { _ in }
-        expectedRequestError = RequestError.internalServiceError
+        expectedRequestError = RequestError.internalServiceError("")
         eventSource = PyroEventSource.create(baseURL: baseURL, accessToken: accessToken)
         eventSource.state = .open
         eventSource.callback = self
@@ -213,7 +213,7 @@ class PyroEventSourceTest: XCTestCase {
             XCTAssertTrue(self.eventSource.state == .open)
             expectation1.fulfill()
         }
-        expectedRequestError = RequestError.internalServiceError
+        expectedRequestError = RequestError.internalServiceError("")
         eventSource = PyroEventSource.create(baseURL: baseURL, accessToken: accessToken)
         eventSource.state = .open
         eventSource.callback = self
@@ -252,7 +252,7 @@ class PyroEventSourceTest: XCTestCase {
         let session = URLSession()
         let httpResponse = HTTPURLResponse(url: URL(string: "https://sampleio.com")!, statusCode: 500, httpVersion: nil, headerFields: nil)
         let task = URLSessionDataTaskMock(httpResponse: httpResponse)
-        expectedRequestError = RequestError.internalServiceError
+        expectedRequestError = RequestError.internalServiceError("")
         eventSource = PyroEventSource.create(baseURL: baseURL, accessToken: accessToken)
         eventSource.state = .open
         eventSource.callback = self

--- a/PyrobaseTests/RequestErrorTest.swift
+++ b/PyrobaseTests/RequestErrorTest.swift
@@ -1,0 +1,53 @@
+//
+//  RequestErrorTest.swift
+//  Pyrobase
+//
+//  Created by Mounir Ybanez on 26/07/2017.
+//  Copyright © 2017 Ner. All rights reserved.
+//
+
+import XCTest
+@testable import Pyrobase
+
+class RequestErrorTest: XCTestCase {
+    
+    func testCode() {
+        XCTAssertEqual(RequestError.invalidURL.code, -9000)
+        XCTAssertEqual(RequestError.unparseableJSON.code, -9001)
+        XCTAssertEqual(RequestError.noURLResponse.code, -9002)
+        XCTAssertEqual(RequestError.nullJSON.code, -9003)
+        XCTAssertEqual(RequestError.unknown.code, -9004)
+        
+        XCTAssertEqual(RequestError.badRequest("").code, -9005)
+        XCTAssertEqual(RequestError.unauthorized("").code, -9006)
+        XCTAssertEqual(RequestError.forbidden("").code, -9007)
+        XCTAssertEqual(RequestError.notFound("").code, -9008)
+        XCTAssertEqual(RequestError.internalServiceError("").code, -9009)
+        XCTAssertEqual(RequestError.serviceUnavailable("").code, -9010)
+    }
+    
+    func testMessage() {
+        XCTAssertEqual(RequestError.invalidURL.message, "URL is invalid")
+        XCTAssertEqual(RequestError.unparseableJSON.message, "Can not parse JSON")
+        XCTAssertEqual(RequestError.noURLResponse.message, "No URL response")
+        XCTAssertEqual(RequestError.nullJSON.message, "JSON is null")
+        XCTAssertEqual(RequestError.unknown.message, "Unknown error encountered")
+        
+        XCTAssertEqual(RequestError.badRequest("Bad request").message, "Bad request")
+        XCTAssertEqual(RequestError.unauthorized("Unauthorized").message, "Unauthorized")
+        XCTAssertEqual(RequestError.forbidden("Forbidden").message, "Forbidden")
+        XCTAssertEqual(RequestError.notFound("Not Found").message, "Not Found")
+        XCTAssertEqual(RequestError.internalServiceError("Internal Service Error").message, "Internal Service Error")
+        XCTAssertEqual(RequestError.serviceUnavailable("Service Unavailable").message, "Service Unavailable")
+    }
+    
+    func testEquality() {
+        XCTAssertEqual(RequestError.invalidURL, RequestError.invalidURL)
+        XCTAssertNotEqual(RequestError.invalidURL, RequestError.noURLResponse)
+        XCTAssertNotEqual(RequestError.invalidURL, RequestError.badRequest("Bad request"))
+        XCTAssertEqual(RequestError.badRequest("Bad request"), RequestError.badRequest("Bad request"))
+        XCTAssertNotEqual(RequestError.badRequest("Bad request"), RequestError.badRequest("Worse request"))
+        XCTAssertNotEqual(RequestError.badRequest("Bad request"), RequestError.unauthorized("Unauthorized"))
+    }
+}
+

--- a/PyrobaseTests/RequestResponseTest.swift
+++ b/PyrobaseTests/RequestResponseTest.swift
@@ -15,38 +15,38 @@ class RequestResponseTest: XCTestCase {
         let response = RequestResponse()
         
         var httpResponse = HTTPURLResponse(url: URL(string: "https://sampleio.com")!, statusCode: 400, httpVersion: nil, headerFields: nil)!
-        var error = response.isErroneous(httpResponse)
+        var error = response.isErroneous(httpResponse, data: nil)
         XCTAssertNotNil(error)
-        XCTAssertTrue(error as! RequestError == .badRequest)
+        XCTAssertTrue(error as! RequestError == .badRequest(""))
     
         httpResponse = HTTPURLResponse(url: URL(string: "https://sampleio.com")!, statusCode: 401, httpVersion: nil, headerFields: nil)!
-        error = response.isErroneous(httpResponse)
+        error = response.isErroneous(httpResponse, data: nil)
         XCTAssertNotNil(error)
-        XCTAssertTrue(error as! RequestError == .unauthorized)
+        XCTAssertTrue(error as! RequestError == .unauthorized(""))
     
         httpResponse = HTTPURLResponse(url: URL(string: "https://sampleio.com")!, statusCode: 403, httpVersion: nil, headerFields: nil)!
-        error = response.isErroneous(httpResponse)
+        error = response.isErroneous(httpResponse, data: nil)
         XCTAssertNotNil(error)
-        XCTAssertTrue(error as! RequestError == .forbidden)
+        XCTAssertTrue(error as! RequestError == .forbidden(""))
     
         httpResponse = HTTPURLResponse(url: URL(string: "https://sampleio.com")!, statusCode: 404, httpVersion: nil, headerFields: nil)!
-        error = response.isErroneous(httpResponse)
+        error = response.isErroneous(httpResponse, data: nil)
         XCTAssertNotNil(error)
-        XCTAssertTrue(error as! RequestError == .notFound)
+        XCTAssertTrue(error as! RequestError == .notFound(""))
         
         httpResponse = HTTPURLResponse(url: URL(string: "https://sampleio.com")!, statusCode: 500, httpVersion: nil, headerFields: nil)!
-        error = response.isErroneous(httpResponse)
+        error = response.isErroneous(httpResponse, data: nil)
         XCTAssertNotNil(error)
-        XCTAssertTrue(error as! RequestError == .internalServiceError)
+        XCTAssertTrue(error as! RequestError == .internalServiceError(""))
         
         httpResponse = HTTPURLResponse(url: URL(string: "https://sampleio.com")!, statusCode: 503, httpVersion: nil, headerFields: nil)!
-        error = response.isErroneous(httpResponse)
+        error = response.isErroneous(httpResponse, data: nil)
         XCTAssertNotNil(error)
-        XCTAssertTrue(error as! RequestError == .serviceUnavailable)
+        XCTAssertTrue(error as! RequestError == .serviceUnavailable(""))
         
         httpResponse = HTTPURLResponse(url: URL(string: "https://sampleio.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
-        error = response.isErroneous(httpResponse)
+        error = response.isErroneous(httpResponse, data: nil)
         XCTAssertNil(error)
-        XCTAssertNil(response.isErroneous(nil))
+        XCTAssertNil(response.isErroneous(nil, data: nil))
     }
 }

--- a/PyrobaseTests/RequestTest.swift
+++ b/PyrobaseTests/RequestTest.swift
@@ -598,7 +598,7 @@ class RequestTest: XCTestCase {
             case .failed(let info):
                 XCTAssertTrue(info is RequestError)
                 let resultInfo = info as! RequestError
-                XCTAssertTrue(resultInfo == RequestError.badRequest)
+                XCTAssertTrue(resultInfo == .badRequest(""))
             }
             expectation1.fulfill()
         }
@@ -624,7 +624,7 @@ class RequestTest: XCTestCase {
             case .failed(let info):
                 XCTAssertTrue(info is RequestError)
                 let errorInfo = info as! RequestError
-                XCTAssertTrue(errorInfo == RequestError.internalServiceError)
+                XCTAssertTrue(errorInfo == .internalServiceError(""))
             }
             expectation1.fulfill()
         }
@@ -650,7 +650,7 @@ class RequestTest: XCTestCase {
             case .failed(let info):
                 XCTAssertTrue(info is RequestError)
                 let errorInfo = info as! RequestError
-                XCTAssertTrue(errorInfo == RequestError.notFound)
+                XCTAssertTrue(errorInfo == .notFound(""))
             }
             expectation1.fulfill()
         }


### PR DESCRIPTION
- Added code and message property in `RequestError`
- `RequestError` implemented `Equatable` protocol
- `RequestError` is equal if code and message are the same
- Defined static message for `invalidURL`, `unparseableJSON`, `noURLResponse`, `nullJSON`,  and `unknown` cases
- Defined code for `RequestError` cases
- Will resolve issue #1 